### PR TITLE
Kmeans mojo - initialize centroids same way in all three implementations

### DIFF
--- a/blogs/mojo-kmeans-from-python/mojo_kmeans/kmeans.mojo
+++ b/blogs/mojo-kmeans-from-python/mojo_kmeans/kmeans.mojo
@@ -1,10 +1,10 @@
 from .matrix import Matrix
-from .utils import list_to_matrix
+from utils.numerics import max_or_inf
+from .utils import list_to_matrix, kmeans_plus_plus, distance_norm
 from algorithm import vectorize, parallelize
 from random import random_si64, random_float64, seed
 from memory import memcpy
 from sys import info
-import math
 from time import now
 from python import Python
 
@@ -18,81 +18,29 @@ struct Kmeans[dtype: DType=DType.float64]():
     var run_till_max_iter: Bool
     alias simd_width: Int=4*simdwidthof[dtype]()
 
-    fn __init__(inout self, 
-                k: Int=8, 
+    fn __init__(inout self,
+                centroids: List[Matrix[dtype]],
                 max_iterations: Int=300, 
                 tol: Scalar[dtype]=1e-4, 
                 rng_seed: Int=42,
                 verbose: Bool=True,
                 run_till_max_iter: Bool=False):
-        self.k=k  # Number of clusters
+        self.k=len(centroids)  # Number of clusters
         self.max_iterations=max_iterations # Maximum number of iterations to run the algorithm
         self.tol=tol  # Tolerance for convergence. Stop if the change in inertia is less than tol.
-        self.centroids=List[Matrix[dtype]](capacity=k) # List to store the centroids of clusters
+        self.centroids=centroids # List to store the centroids of clusters
         self.inertia=0.0  # Measure of the total distance of each point to its assigned centroid
         self.verbose=verbose  # Controls whether to print detailed debug statements
         self.run_till_max_iter=run_till_max_iter  # Run till max_iterations even if converged
         seed(rng_seed) # Seed for random number generation, for reproducibility
 
-    # Calculate squared Euclidean distance from each data point to each centroid
-    fn distance_norm(self, data: Matrix[dtype], 
-                    inout centroids_distances: Matrix[dtype]):
-        alias simd_width=self.simd_width
-        var simd_multiple=math.align_down(data.cols, simd_width)
-        @parameter
-        fn parallel_sqnorm(idx_centroid: Int):
-            var centroid=self.centroids[idx_centroid]
-            for idx_mat_row in range(data.rows):
-                var sq_norm=SIMD[dtype, simd_width].splat(0)
-                for idx_col in range(0, simd_multiple, simd_width):
-                    sq_norm += math.pow(
-                        data._matPtr.load[width=simd_width](idx_mat_row*data.cols+idx_col) - 
-                        centroid._matPtr.load[width=simd_width](idx_col),2)
-                for idx_col in range(simd_multiple, data.cols):
-                    sq_norm[0] += math.pow(
-                        data._matPtr.load[width=1](idx_mat_row*data.cols+idx_col) - 
-                        centroid._matPtr.load[width=1](idx_col),2
-                        )
-                centroids_distances[idx_mat_row, idx_centroid]=sq_norm.reduce_add()
-        parallelize[parallel_sqnorm](len(self.centroids), info.num_performance_cores())
-
-    # Initialize centroids using the k-means++ algorithm to improve cluster quality
-    fn _kmeans_plus_plus(inout self, data: Matrix[dtype]) raises:
-        # Declare temporary variables
-        var probs: Matrix[dtype]
-        var cumulative_probs: Matrix[dtype]
-
-        # Add the first centroid randomly chosen from the data
-        self.centroids.append(data[int(random_si64(0,data.rows)),:])
-
-        # Create a full matrix for distance calculations; start with infinity
-        var centroids_distances=Matrix[dtype](data.rows, self.k, math.limit.inf[dtype]())
-
-        for idx_c in range(1, self.k):
-            # Update distances for all points relative to the new set of centroids
-            self.distance_norm(data, centroids_distances)
-            # Find the minimum distance to any centroid for each point
-            var min_distances=centroids_distances.min[axis=1]() 
-
-            # Probability of selecting next centroid is proportional to squared distance
-            probs=min_distances / min_distances.sum()
-            # Cumulative probabilities for selection
-            cumulative_probs=probs.cumsum() 
-
-            # Select the next centroid based on cumulative probabilities
-            var rand_prob=random_float64().cast[dtype]()
-            for i in range(len(cumulative_probs)):
-                if rand_prob < cumulative_probs[i]:
-                    self.centroids.append(data[i,:])
-                    break
-
     # Lloyd's algorithm: Recompute centroids and assign points to the nearest cluster
     fn _lloyds_iteration(inout self, data: Matrix[dtype], 
                                     inout centroids_distances: Matrix[dtype]) raises:
         # Update distances based on current centroids
-        self.distance_norm(data, centroids_distances)
+        distance_norm[dtype, self.simd_width](self.centroids, data, centroids_distances)
         # Assign each point to the nearest centroid
-        var labels=centroids_distances.argmin(axis=1)
+        var labels=centroids_distances.argmin()
 
         # Recalculate centroids as the mean of all points assigned to each centroid
         for idx in range(self.k):
@@ -107,10 +55,8 @@ struct Kmeans[dtype: DType=DType.float64]():
     fn fit(inout self, data: Matrix[dtype]) raises -> List[Matrix[dtype]]:
 
         # Initialize distance matrix
-        var centroids_distances=Matrix[dtype](data.rows, self.k, math.limit.inf[dtype]())
+        var centroids_distances=Matrix[dtype](data.rows, self.k, max_or_inf[dtype]())
 
-        # Initialize centroids using k-means++
-        self._kmeans_plus_plus(data)
         var previous_inertia=self.inertia
 
         for i in range(self.max_iterations):
@@ -121,7 +67,7 @@ struct Kmeans[dtype: DType=DType.float64]():
             # Perform an iteration of Lloyd's algorithm
             self._lloyds_iteration(data, centroids_distances)
 
-            if math.abs(previous_inertia - self.inertia) < self.tol and not self.run_till_max_iter:
+            if abs(previous_inertia - self.inertia) < self.tol and not self.run_till_max_iter:
                 print("Converged at iteration:",i,
                 "Inertia change less than tol:",self.tol,
                 "\n Final inertia:",self.inertia)

--- a/blogs/mojo-kmeans-from-python/mojo_kmeans/utils.mojo
+++ b/blogs/mojo-kmeans-from-python/mojo_kmeans/utils.mojo
@@ -1,4 +1,6 @@
+from math.math import align_down
 from .matrix import Matrix
+
 fn list_to_matrix[dtype: DType](lst: List[Matrix[dtype]]) -> Matrix[dtype]:
     var new_mat = Matrix[dtype](len(lst),len(lst[0]))
     var tmpPtr = new_mat._matPtr
@@ -6,3 +8,59 @@ fn list_to_matrix[dtype: DType](lst: List[Matrix[dtype]]) -> Matrix[dtype]:
         memcpy(tmpPtr, arr[]._matPtr, len(arr[]))
         tmpPtr += len(arr[])
     return new_mat
+
+
+# Initialize centroids using the k-means++ algorithm to improve cluster quality
+fn kmeans_plus_plus[dtype: DType = DType.float64, simd_width: Int = simdwidthof[dtype]()](data: Matrix[dtype], n_clusters: Int) raises -> List[Matrix[dtype]]:
+    # Declare temporary variables
+    var probs: Matrix[dtype]
+    var cumulative_probs: Matrix[dtype]
+    var centroids: List[Matrix[dtype]] = List[Matrix[dtype]](capacity=n_clusters)
+
+    # Add the first centroid randomly chosen from the data
+    centroids.append(data[int(random_si64(0, data.rows)),:])
+
+    # Create a full matrix for distance calculations; start with infinity
+    var centroids_distances=Matrix[dtype](data.rows, n_clusters, max_or_inf[dtype]())
+
+    for idx_c in range(1, n_clusters):
+        # Update distances for all points relative to the new set of centroids
+        distance_norm[dtype, simd_width](centroids, data, centroids_distances)
+        # Find the minimum distance to any centroid for each point
+        var min_distances=centroids_distances.min[axis=1]() 
+
+        # Probability of selecting next centroid is proportional to squared distance
+        probs=min_distances / min_distances.sum()
+        # Cumulative probabilities for selection
+        cumulative_probs=probs.cumsum() 
+
+        # Select the next centroid based on cumulative probabilities
+        var rand_prob=random_float64().cast[dtype]()
+        for i in range(len(cumulative_probs)):
+            if rand_prob < cumulative_probs[i]:
+                centroids.append(data[i,:])
+                break
+        
+    return centroids
+
+
+# Calculate squared Euclidean distance from each data point to each centroid
+fn distance_norm[dtype: DType, simd_width: Int](centroids: List[Matrix[dtype]], data: Matrix[dtype], 
+                inout centroids_distances: Matrix[dtype]):
+    var simd_multiple=align_down(data.cols, simd_width)
+    @parameter
+    fn parallel_sqnorm(idx_centroid: Int):
+        var centroid=centroids[idx_centroid]
+        for idx_mat_row in range(data.rows):
+            var sq_norm=SIMD[dtype, simd_width].splat(0)
+            for idx_col in range(0, simd_multiple, simd_width):
+                sq_norm += pow(
+                    data._matPtr.load[width=simd_width](idx_mat_row*data.cols+idx_col) - 
+                    centroid._matPtr.load[width=simd_width](idx_col),2)
+            for idx_col in range(simd_multiple, data.cols):
+                sq_norm[0] += pow(
+                    data._matPtr.load[width=1](idx_mat_row*data.cols+idx_col) - 
+                    centroid._matPtr.load[width=1](idx_col),2
+                    )
+            centroids_distances[idx_mat_row, idx_centroid]=sq_norm.reduce_add()
+    parallelize[parallel_sqnorm](len(centroids), info.num_performance_cores())

--- a/blogs/mojo-kmeans-from-python/python_kmeans/kmeans.py
+++ b/blogs/mojo-kmeans-from-python/python_kmeans/kmeans.py
@@ -3,16 +3,16 @@ from numpy.random import seed
 
 class Kmeans:
     def __init__(self, 
-                 k=8, 
+                 centroids, 
                  max_iterations=300, 
                  tol=1e-4, 
                  rng_seed=42, 
                  verbose=True, 
                  run_till_max_iter=False):
-        self.k=k  # Number of clusters
+        self.k=len(centroids)  # Number of clusters
         self.max_iterations=max_iterations # Maximum number of iterations to run the algorithm
         self.tol=tol  # Tolerance for convergence. Stop if the change in inertia is less than tol.
-        self.centroids=[]  # List to store the centroids of clusters
+        self.centroids=centroids  # List to store the centroids of clusters
         self.inertia=0.0  # Measure of the total distance of each point to its assigned centroid
         self.verbose=verbose  # Controls whether to print detailed debug statements
         self.run_till_max_iter=run_till_max_iter  # Run till max_iterations even if converged
@@ -20,34 +20,8 @@ class Kmeans:
 
     # Calculate squared Euclidean distance from each data point to each centroid
     def distance_norm(self, data, centroids_distances):
-        centroids_distances[:, :len(self.centroids)] = \
+        centroids_distances[:, :self.centroids.shape[0]] = \
             np.array([[np.linalg.norm(x - c)**2 for c in self.centroids] for x in data])
-
-    # Initialize centroids using the k-means++ algorithm to improve cluster quality
-    def _kmeans_plus_plus(self, data):
-        # Add the first centroid randomly chosen from the data
-        self.centroids.append(data[np.random.randint(data.shape[0])])  
-
-        # Create a full matrix for distance calculations; start with infinity
-        centroids_distances=np.full((data.shape[0], self.k), np.inf)
-
-        for idx_c in range(1, self.k):
-            # Update distances for all points relative to the new set of centroids
-            self.distance_norm(data, centroids_distances)
-            # Find the minimum distance to any centroid for each point
-            min_distances=centroids_distances.min(axis=1)
-
-            # Probability of selecting next centroid is proportional to squared distance
-            probs=min_distances / min_distances.sum()
-            # Cumulative probabilities for selection
-            cumulative_probs=probs.cumsum() 
-
-            # Select the next centroid based on cumulative probabilities
-            rand_prob=np.random.rand()
-            for i in range(len(cumulative_probs)):
-                if rand_prob < cumulative_probs[i]:
-                    self.centroids.append(data[i,:])
-                    break
 
     # Lloyd's algorithm: Recompute centroids and assign points to the nearest cluster
     def _lloyds_iteration(self, data, centroids_distances):
@@ -72,8 +46,6 @@ class Kmeans:
         # Initialize distance matrix
         centroids_distances=np.full((data.shape[0], self.k), np.inf)  
 
-        # Initialize centroids using k-means++
-        self._kmeans_plus_plus(data)
         previous_inertia=self.inertia
 
         for i in range(self.max_iterations):


### PR DESCRIPTION
@shashankprasanna here are the changes I did to make sure centroids are initialized same way for all three implementations (kmeans_plus_plus is now in utils). I did other minor changes to practice and gain confidence with Mojo. Also, had to change some things to work with latest Mojo release.

I doubt that Sklearn performs less iterations, since with the change to how centroids are initialized, I am always getting same inertia in all three implementations which makes the benchmarks fairer.

I did not know how to contact you otherwise, you can ignore this pull request of course.